### PR TITLE
Fixed processing local files.

### DIFF
--- a/Source/WebKit/qt/WebCoreSupport/QWebFrameAdapter.cpp
+++ b/Source/WebKit/qt/WebCoreSupport/QWebFrameAdapter.cpp
@@ -378,15 +378,19 @@ QUrl QWebFrameAdapter::ensureAbsoluteUrl(const QUrl& url)
     if (!validatedUrl.isValid() || !validatedUrl.isRelative())
         return validatedUrl;
 
+    // Since validatedUrl is not relative url (no schema provided)
+    // we are working with file context and need to explicitly specify this.
+    // Otherwise toLocalFile() will return empty string
+    // due to it requires url as local file (i.e. with "file" schema).
+    validatedUrl.setScheme("file");
+
     // This contains the URL with absolute path but without
     // the query and the fragment part.
     QUrl baseUrl = QUrl::fromLocalFile(QFileInfo(validatedUrl.toLocalFile()).absoluteFilePath());
+    baseUrl.setFragment(validatedUrl.fragment());
+    baseUrl.setQuery(validatedUrl.query());
 
-    // The path is removed so the query and the fragment parts are there.
-    QString pathRemoved = validatedUrl.toString(QUrl::RemovePath);
-    QUrl toResolve(pathRemoved);
-
-    return baseUrl.resolved(toResolve);
+    return baseUrl;
 }
 
 QWebHitTestResultPrivate* QWebFrameAdapter::hitTestContent(const QPoint& pos) const


### PR DESCRIPTION
Fixed a bug with processing urls with file schema.
1. Fixed QWebFrameAdapter::ensureAbsoluteUrl
where was a bug to retrieve absolute path if url without schema provided.
2. Changed sequence of adding calls to QNetworkReplyHandlerCallQueue.
Calling sendResponseIfNeeded before forwardData
could lead processing MainResourceLoader::didReceiveResponse
which could cause calling FrameLoaderClientQt::download
where current QNetworkReplyHandler will be released
and QNetworkReplyWrapper will be destroyed.
Within destruction It will also clear exact reply handler call queue including unprocessed yet subsequent calls
(e.g. forwardData where data read is handled).
